### PR TITLE
update to latest std.zig.tokenizer API

### DIFF
--- a/src/doctest/syntax.zig
+++ b/src/doctest/syntax.zig
@@ -16,105 +16,103 @@ pub fn highlightZigCode(raw_src: []const u8, out: anytype) !void {
 
         const token = tokenizer.next();
         try render_utils.writeEscaped(out, src[index..token.loc.start]);
-        switch (token.id) {
-            .Eof => break,
+        switch (token.tag) {
+            .eof => break,
 
-            .Keyword_align,
-            .Keyword_and,
-            .Keyword_asm,
-            .Keyword_async,
-            .Keyword_await,
-            .Keyword_break,
-            .Keyword_catch,
-            .Keyword_comptime,
-            .Keyword_const,
-            .Keyword_continue,
-            .Keyword_defer,
-            .Keyword_else,
-            .Keyword_enum,
-            .Keyword_errdefer,
-            .Keyword_error,
-            .Keyword_export,
-            .Keyword_extern,
-            .Keyword_for,
-            .Keyword_if,
-            .Keyword_inline,
-            .Keyword_noalias,
-            .Keyword_noinline,
-            .Keyword_nosuspend,
-            .Keyword_opaque,
-            .Keyword_or,
-            .Keyword_orelse,
-            .Keyword_packed,
-            .Keyword_anyframe,
-            .Keyword_pub,
-            .Keyword_resume,
-            .Keyword_return,
-            .Keyword_linksection,
-            .Keyword_callconv,
-            .Keyword_struct,
-            .Keyword_suspend,
-            .Keyword_switch,
-            .Keyword_test,
-            .Keyword_threadlocal,
-            .Keyword_try,
-            .Keyword_union,
-            .Keyword_unreachable,
-            .Keyword_usingnamespace,
-            .Keyword_var,
-            .Keyword_volatile,
-            .Keyword_allowzero,
-            .Keyword_while,
-            .Keyword_anytype,
+            .keyword_align,
+            .keyword_and,
+            .keyword_asm,
+            .keyword_async,
+            .keyword_await,
+            .keyword_break,
+            .keyword_catch,
+            .keyword_comptime,
+            .keyword_const,
+            .keyword_continue,
+            .keyword_defer,
+            .keyword_else,
+            .keyword_enum,
+            .keyword_errdefer,
+            .keyword_error,
+            .keyword_export,
+            .keyword_extern,
+            .keyword_for,
+            .keyword_if,
+            .keyword_inline,
+            .keyword_noalias,
+            .keyword_noinline,
+            .keyword_nosuspend,
+            .keyword_opaque,
+            .keyword_or,
+            .keyword_orelse,
+            .keyword_packed,
+            .keyword_anyframe,
+            .keyword_pub,
+            .keyword_resume,
+            .keyword_return,
+            .keyword_linksection,
+            .keyword_callconv,
+            .keyword_struct,
+            .keyword_suspend,
+            .keyword_switch,
+            .keyword_test,
+            .keyword_threadlocal,
+            .keyword_try,
+            .keyword_union,
+            .keyword_unreachable,
+            .keyword_usingnamespace,
+            .keyword_var,
+            .keyword_volatile,
+            .keyword_allowzero,
+            .keyword_while,
+            .keyword_anytype,
             => {
                 try out.writeAll("<span class=\"tok-kw\">");
                 try render_utils.writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
-            .Keyword_fn => {
+            .keyword_fn => {
                 try out.writeAll("<span class=\"tok-kw\">");
                 try render_utils.writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
                 next_tok_is_fn = true;
             },
 
-            .Keyword_undefined,
-            .Keyword_null,
-            .Keyword_true,
-            .Keyword_false,
+            .keyword_undefined,
+            .keyword_null,
+            .keyword_true,
+            .keyword_false,
             => {
                 try out.writeAll("<span class=\"tok-null\">");
                 try render_utils.writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
-            .StringLiteral,
-            .MultilineStringLiteralLine,
-            .CharLiteral,
+            .string_literal,
+            .multiline_string_literal_line,
+            .char_literal,
             => {
                 try out.writeAll("<span class=\"tok-str\">");
                 try render_utils.writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
-            .Builtin => {
+            .builtin => {
                 try out.writeAll("<span class=\"tok-builtin\">");
                 try render_utils.writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
-            .LineComment,
-            .DocComment,
-            .ContainerDocComment,
-            .ShebangLine,
+            .doc_comment,
+            .container_doc_comment,
             => {
                 try out.writeAll("<span class=\"tok-comment\">");
                 try render_utils.writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
-            .Identifier => {
+            .identifier => {
                 if (prev_tok_was_fn) {
                     try out.writeAll("<span class=\"tok-fn\">");
                     try render_utils.writeEscaped(out, src[token.loc.start..token.loc.end]);
@@ -142,71 +140,71 @@ pub fn highlightZigCode(raw_src: []const u8, out: anytype) !void {
                 }
             },
 
-            .IntegerLiteral,
-            .FloatLiteral,
+            .integer_literal,
+            .float_literal,
             => {
                 try out.writeAll("<span class=\"tok-number\">");
                 try render_utils.writeEscaped(out, src[token.loc.start..token.loc.end]);
                 try out.writeAll("</span>");
             },
 
-            .Bang,
-            .Pipe,
-            .PipePipe,
-            .PipeEqual,
-            .Equal,
-            .EqualEqual,
-            .EqualAngleBracketRight,
-            .BangEqual,
-            .LParen,
-            .RParen,
-            .Semicolon,
-            .Percent,
-            .PercentEqual,
-            .LBrace,
-            .RBrace,
-            .LBracket,
-            .RBracket,
-            .Period,
-            .PeriodAsterisk,
-            .Ellipsis2,
-            .Ellipsis3,
-            .Caret,
-            .CaretEqual,
-            .Plus,
-            .PlusPlus,
-            .PlusEqual,
-            .PlusPercent,
-            .PlusPercentEqual,
-            .Minus,
-            .MinusEqual,
-            .MinusPercent,
-            .MinusPercentEqual,
-            .Asterisk,
-            .AsteriskEqual,
-            .AsteriskAsterisk,
-            .AsteriskPercent,
-            .AsteriskPercentEqual,
-            .Arrow,
-            .Colon,
-            .Slash,
-            .SlashEqual,
-            .Comma,
-            .Ampersand,
-            .AmpersandEqual,
-            .QuestionMark,
-            .AngleBracketLeft,
-            .AngleBracketLeftEqual,
-            .AngleBracketAngleBracketLeft,
-            .AngleBracketAngleBracketLeftEqual,
-            .AngleBracketRight,
-            .AngleBracketRightEqual,
-            .AngleBracketAngleBracketRight,
-            .AngleBracketAngleBracketRightEqual,
-            .Tilde,
+            .bang,
+            .pipe,
+            .pipe_pipe,
+            .pipe_equal,
+            .equal,
+            .equal_equal,
+            .equal_angle_bracket_right,
+            .bang_equal,
+            .l_paren,
+            .r_paren,
+            .semicolon,
+            .percent,
+            .percent_equal,
+            .l_brace,
+            .r_brace,
+            .l_bracket,
+            .r_bracket,
+            .period,
+            .period_asterisk,
+            .ellipsis2,
+            .ellipsis3,
+            .caret,
+            .caret_equal,
+            .plus,
+            .plus_plus,
+            .plus_equal,
+            .plus_percent,
+            .plus_percent_equal,
+            .minus,
+            .minus_equal,
+            .minus_percent,
+            .minus_percent_equal,
+            .asterisk,
+            .asterisk_equal,
+            .asterisk_asterisk,
+            .asterisk_percent,
+            .asterisk_percent_equal,
+            .arrow,
+            .colon,
+            .slash,
+            .slash_equal,
+            .comma,
+            .ampersand,
+            .ampersand_equal,
+            .question_mark,
+            .angle_bracket_left,
+            .angle_bracket_left_equal,
+            .angle_bracket_angle_bracket_left,
+            .angle_bracket_angle_bracket_left_equal,
+            .angle_bracket_right,
+            .angle_bracket_right_equal,
+            .angle_bracket_angle_bracket_right,
+            .angle_bracket_angle_bracket_right_equal,
+            .tilde,
             => try render_utils.writeEscaped(out, src[token.loc.start..token.loc.end]),
 
-            .Invalid, .Invalid_ampersands, .Invalid_periodasterisks => return parseError(
+            .invalid, .invalid_ampersands, .invalid_periodasterisks => return parseError(
                 src,
                 token,
                 "syntax error",
@@ -222,7 +220,7 @@ pub fn highlightZigCode(raw_src: []const u8, out: anytype) !void {
 fn parseError(src: []const u8, token: std.zig.Token, comptime fmt: []const u8, args: anytype) anyerror {
     const loc = getTokenLocation(src, token);
     // const args_prefix = .{ tokenizer.source_file_name, loc.line + 1, loc.column + 1 };
-    // print("{}:{}:{}: error: " ++ fmt ++ "\n", args_prefix ++ args);
+    // print("{s}:{d}:{d}: error: " ++ fmt ++ "\n", args_prefix ++ args);
 
     const args_prefix = .{ loc.line + 1, loc.column + 1 };
     print("{d}:{d}: error: " ++ fmt ++ "\n", args_prefix ++ args);


### PR DESCRIPTION
Fixes CI failure deploying the website. I think it makes line comments render differently. I'd like to suggest solving this by making the default css style line comments, and having other tokens override it, since line comments are the only non-whitespace omitted from the token list.