### PR TITLE
update to latest zig

### DIFF
--- a/zig-clap/clap.zig
+++ b/zig-clap/clap.zig
@@ -74,7 +74,7 @@ pub fn parseParam(line: []const u8) !Param(Help) {
     @setEvalBranchQuota(std.math.maxInt(u32));
 
     var found_comma = false;
-    var it = mem.tokenize(line, " \t");
+    var it = mem.tokenize(u8, line, " \t");
     var param_str = it.next() orelse return error.NoParamFound;
 
     const short_name = if (!mem.startsWith(u8, param_str, "--") and


### PR DESCRIPTION
`std.mem.tokenize` signature changed to

`fn tokenize(comptime T: type, buffer: []const T, delimiter_bytes: []const T) TokenIterator(T)`