### PR TITLE
fix open_output() return type for windows

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -534,9 +534,7 @@ fn check_help(comptime summary: []const u8, comptime params: anytype, args: anyt
     }
 }
 
-// Nothing to see here, just a normal elegant generic type.
-const BufferedFileType = @TypeOf(io.bufferedWriter((std.fs.File{ .handle = 0 }).writer()));
-fn open_output(output: ?[]const u8) !BufferedFileType {
+fn open_output(output: ?[]const u8) !io.BufferedWriter(4096, fs.File.Writer) {
     const out_file = if (output) |out_file_name|
         try fs.cwd().createFile(out_file_name, .{})
     else


### PR DESCRIPTION
This problem was once solved in #1. However, that line was overwritten by f77e5270a4702e127f623e4fbfc593429a687f43.