### PR TITLE
Update for latest Zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,13 +13,13 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "doctest",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     exe.root_module.addAnonymousImport("clap", .{
-        .root_source_file = .{ .path = "zig-clap/clap.zig" },
+        .root_source_file = b.path("zig-clap/clap.zig"),
     });
     b.installArtifact(exe);
 


### PR DESCRIPTION
Must use `b.path` instead, constructing a LazyPath like this is deprecated since dee9f82f69db0d034251b844e0bc4083a1b25fdd.